### PR TITLE
updated samples with clms-metadata tool v0.1.7

### DIFF
--- a/ba_global_300m_daily_v3.json
+++ b/ba_global_300m_daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_BA300-NRT_202402200000_GLOBE_S3_V3.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2024-02-22T06:28:53Z",
+  "OriginDate": "2024-02-22T06:28:53.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/burnt_area/ba_300m_v3_daily/2024/20240220/c_gls_BA300-NRT_202402200000_GLOBE_S3_V3.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2024-02-20T00:00:00Z",
-    "End": "2024-02-20T23:59:59Z"
+    "Start": "2024-02-20T00:00:00.000000Z",
+    "End": "2024-02-20T23:59:59.999999Z"
   },
-  "NominalDate": "2024-02-20T00:00:00Z",
+  "NominalDate": "2024-02-20T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/ba_global_300m_monthly_v3.json
+++ b/ba_global_300m_monthly_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_BA300-NTC_202306010000_GLOBE_S3_V3.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2024-05-10T20:30:25Z",
+  "OriginDate": "2024-05-10T20:30:25.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/burnt_area/ba_300m_v3_monthly/2023/20230601/c_gls_BA300-NTC_202306010000_GLOBE_S3_V3.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-06-01T00:00:00Z",
-    "End": "2023-06-30T23:59:59Z"
+    "Start": "2023-06-01T00:00:00.000000Z",
+    "End": "2023-06-30T23:59:59.999999Z"
   },
-  "NominalDate": "2023-06-01T00:00:00Z",
+  "NominalDate": "2023-06-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/dmp_global_1km_10daily_v2.json
+++ b/dmp_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_DMP_200109100000_GLOBE_VGT_V2.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-11T20:01:50Z",
+  "OriginDate": "2023-02-11T20:01:50.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/dmp_1km_v2_10daily/2001/20010910/c_gls_DMP_200109100000_GLOBE_VGT_V2.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2001-09-01T00:00:00Z",
-    "End": "2001-09-10T23:59:59Z"
+    "Start": "2001-09-01T00:00:00.000000Z",
+    "End": "2001-09-10T23:59:59.999999Z"
   },
-  "NominalDate": "2001-09-10T00:00:00Z",
+  "NominalDate": "2001-09-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/dmp_global_300m_10daily_v1.json
+++ b/dmp_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_DMP300-RT5_201502200000_GLOBE_PROBAV_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-11T20:09:47Z",
+  "OriginDate": "2023-02-11T20:09:47.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/dmp_300m_v1_10daily/2015/20150220/c_gls_DMP300-RT5_201502200000_GLOBE_PROBAV_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2015-02-11T00:00:00Z",
-    "End": "2015-02-20T23:59:59Z"
+    "Start": "2015-02-11T00:00:00.000000Z",
+    "End": "2015-02-20T23:59:59.999999Z"
   },
-  "NominalDate": "2015-02-20T00:00:00Z",
+  "NominalDate": "2015-02-20T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/fapar_global_1km_10daily_v2.json
+++ b/fapar_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_FAPAR_199908100000_GLOBE_VGT_V2.0.2_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2017-04-18T16:06:35Z",
+  "OriginDate": "2017-04-18T16:06:35.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/fraction_absorbed_par/fapar_1km_v2_10daily/1999/19990810/c_gls_FAPAR_199908100000_GLOBE_VGT_V2.0.2.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "1999-08-01T00:00:00Z",
-    "End": "1999-08-10T23:59:59.999Z"
+    "Start": "1999-08-01T00:00:00.000000Z",
+    "End": "1999-08-10T23:59:59.999999Z"
   },
-  "NominalDate": "1999-08-10T00:00:00Z",
+  "NominalDate": "1999-08-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/fapar_global_300m_10daily_v1.json
+++ b/fapar_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_FAPAR300-RT6_202302100000_GLOBE_OLCI_V1.1.2_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-04-14T08:53:45Z",
+  "OriginDate": "2023-04-14T08:53:45.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/fraction_absorbed_par/fapar_300m_v1_10daily/2023/20230210/c_gls_FAPAR300-RT6_202302100000_GLOBE_OLCI_V1.1.2.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-02-01T00:00:00Z",
-    "End": "2023-02-10T23:59:59.999Z"
+    "Start": "2023-02-01T00:00:00.000000Z",
+    "End": "2023-02-10T23:59:59.999999Z"
   },
-  "NominalDate": "2023-02-10T00:00:00Z",
+  "NominalDate": "2023-02-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,12 +114,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/fcover_global_1km_10daily_v2.json
+++ b/fcover_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_FCOVER-RT2_201909100000_GLOBE_PROBAV_V2.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-10-02T08:24:31Z",
+  "OriginDate": "2019-10-02T08:24:31.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/fraction_green_cover/fcover_1km_v2_10daily/2019/20190910/c_gls_FCOVER-RT2_201909100000_GLOBE_PROBAV_V2.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2019-09-01T00:00:00Z",
-    "End": "2019-09-10T23:59:59.999Z"
+    "Start": "2019-09-01T00:00:00.000000Z",
+    "End": "2019-09-10T23:59:59.999999Z"
   },
-  "NominalDate": "2019-09-10T00:00:00Z",
+  "NominalDate": "2019-09-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/fcover_global_300m_10daily_v1.json
+++ b/fcover_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_FCOVER300_201503200000_GLOBE_PROBAV_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-13T14:18:36Z",
+  "OriginDate": "2023-02-13T14:18:36.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/fraction_green_cover/fcover_300m_v1_10daily/2015/20150320/c_gls_FCOVER300_201503200000_GLOBE_PROBAV_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2015-03-11T00:00:00Z",
-    "End": "2015-03-20T23:59:59.999Z"
+    "Start": "2015-03-11T00:00:00.000000Z",
+    "End": "2015-03-20T23:59:59.999999Z"
   },
-  "NominalDate": "2015-03-20T00:00:00Z",
+  "NominalDate": "2015-03-20T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/gdmp_global_1km_10daily_v2.json
+++ b/gdmp_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_GDMP_199901310000_GLOBE_VGT_V2.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-11T19:41:09Z",
+  "OriginDate": "2023-02-11T19:41:09.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/gdmp_1km_v2_10daily/1999/19990131/c_gls_GDMP_199901310000_GLOBE_VGT_V2.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "1999-01-21T00:00:00Z",
-    "End": "1999-01-31T23:59:59Z"
+    "Start": "1999-01-21T00:00:00.000000Z",
+    "End": "1999-01-31T23:59:59.999999Z"
   },
-  "NominalDate": "1999-01-31T00:00:00Z",
+  "NominalDate": "1999-01-31T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/gdmp_global_300m_10daily_v1.json
+++ b/gdmp_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_GDMP300-RT0_202501100000_GLOBE_OLCI_V1.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2025-01-12T13:45:20Z",
+  "OriginDate": "2025-01-12T13:45:20.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/gdmp_300m_v1_10daily/2025/20250110/c_gls_GDMP300-RT0_202501100000_GLOBE_OLCI_V1.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2025-01-01T00:00:00Z",
-    "End": "2025-01-10T23:59:59Z"
+    "Start": "2025-01-01T00:00:00.000000Z",
+    "End": "2025-01-10T23:59:59.999999Z"
   },
-  "NominalDate": "2025-01-10T00:00:00Z",
+  "NominalDate": "2025-01-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,12 +114,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/gpp_global_300m_10daily_v1.json
+++ b/gpp_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_GPP300-RT2_202410310000_GLOBE_OLCI_V1.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2024-11-23T17:33:17Z",
+  "OriginDate": "2024-11-23T17:33:17.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/gpp_300m_v1_10daily/2024/20241031/c_gls_GPP300-RT2_202410310000_GLOBE_OLCI_V1.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2024-10-21T00:00:00Z",
-    "End": "2024-10-31T23:59:59Z"
+    "Start": "2024-10-21T00:00:00.000000Z",
+    "End": "2024-10-31T23:59:59.999999Z"
   },
-  "NominalDate": "2024-10-31T00:00:00Z",
+  "NominalDate": "2024-10-31T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,12 +114,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lai_global_1km_10daily_v2.json
+++ b/lai_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LAI_200804200000_GLOBE_VGT_V2.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2017-03-26T08:09:03Z",
+  "OriginDate": "2017-03-26T08:09:03.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/leaf_area_index/lai_1km_v2_10daily/2008/20080420/c_gls_LAI_200804200000_GLOBE_VGT_V2.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2008-04-11T00:00:00Z",
-    "End": "2008-04-20T23:59:59.999Z"
+    "Start": "2008-04-11T00:00:00.000000Z",
+    "End": "2008-04-20T23:59:59.999999Z"
   },
-  "NominalDate": "2008-04-20T00:00:00Z",
+  "NominalDate": "2008-04-20T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/lai_global_300m_10daily_v1.json
+++ b/lai_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LAI300_201402200000_GLOBE_PROBAV_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-13T13:33:51Z",
+  "OriginDate": "2023-02-13T13:33:51.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/leaf_area_index/lai_300m_v1_10daily/2014/20140220/c_gls_LAI300_201402200000_GLOBE_PROBAV_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2014-02-11T00:00:00Z",
-    "End": "2014-02-20T23:59:59.999Z"
+    "Start": "2014-02-11T00:00:00.000000Z",
+    "End": "2014-02-20T23:59:59.999999Z"
   },
-  "NominalDate": "2014-02-20T00:00:00Z",
+  "NominalDate": "2014-02-20T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/lst-daily-cycle_global_5km_10daily_v1.json
+++ b/lst-daily-cycle_global_5km_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST10-DC_201909010000_GLOBE_GEO_V1.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-09-11T01:26:33Z",
+  "OriginDate": "2019-09-11T01:26:33.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v1_10daily-daily-cycle/2019/20190901/c_gls_LST10-DC_201909010000_GLOBE_GEO_V1.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2019-09-01T00:00:00Z",
-    "End": "2019-09-10T23:00:00Z"
+    "Start": "2019-09-01T00:00:00.000000Z",
+    "End": "2019-09-10T23:00:00.000000Z"
   },
-  "NominalDate": "2019-09-01T00:00:00Z",
+  "NominalDate": "2019-09-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lst-daily-cycle_global_5km_10daily_v2.json
+++ b/lst-daily-cycle_global_5km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST10-DC_202305210000_GLOBE_GEO_V2.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-06-01T01:20:33Z",
+  "OriginDate": "2023-06-01T01:20:33.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v2_10daily-daily-cycle/2023/20230521/c_gls_LST10-DC_202305210000_GLOBE_GEO_V2.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-05-21T00:00:00Z",
-    "End": "2023-05-31T23:00:00Z"
+    "Start": "2023-05-21T00:00:00.000000Z",
+    "End": "2023-05-31T23:00:00.000000Z"
   },
-  "NominalDate": "2023-05-21T00:00:00Z",
+  "NominalDate": "2023-05-21T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,7 +114,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lst-tci_global_5km_10daily_v1.json
+++ b/lst-tci_global_5km_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST10-TCI_202002210000_GLOBE_GEO_V1.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2020-03-01T01:25:27Z",
+  "OriginDate": "2020-03-01T01:25:27.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v1_10daily-tci/2020/20200221/c_gls_LST10-TCI_202002210000_GLOBE_GEO_V1.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2020-02-21T00:00:00Z",
-    "End": "2020-02-29T23:00:00Z"
+    "Start": "2020-02-21T00:00:00.000000Z",
+    "End": "2020-02-29T23:00:00.000000Z"
   },
-  "NominalDate": "2020-02-21T00:00:00Z",
+  "NominalDate": "2020-02-21T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lst-tci_global_5km_10daily_v2.json
+++ b/lst-tci_global_5km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST10-TCI_202101110000_GLOBE_GEO_V2.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-09-19T09:42:32Z",
+  "OriginDate": "2023-09-19T09:42:32.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v2_10daily-tci/2021/20210111/c_gls_LST10-TCI_202101110000_GLOBE_GEO_V2.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2021-01-11T00:00:00Z",
-    "End": "2021-01-20T23:00:00Z"
+    "Start": "2021-01-11T00:00:00.000000Z",
+    "End": "2021-01-20T23:00:00.000000Z"
   },
-  "NominalDate": "2021-01-11T00:00:00Z",
+  "NominalDate": "2021-01-11T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -74,7 +74,7 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": "HIMAWARI8,GOESR,METEOSAT11,METEOSAT8"
+      "Value": "HIMAWARI8,METEOSAT11,METEOSAT8"
     },
     {
       "Name": "instrumentShortName",
@@ -114,7 +114,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lst_global_5km_hourly_v1.json
+++ b/lst_global_5km_hourly_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST_201409261600_GLOBE_GEO_V1.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-06-30T01:04:22Z",
+  "OriginDate": "2019-06-30T01:04:22.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v1_hourly/2014/20140926/c_gls_LST_201409261600_GLOBE_GEO_V1.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2014-09-26T15:30:00Z",
-    "End": "2014-09-26T16:30:00Z"
+    "Start": "2014-09-26T15:30:00.000000Z",
+    "End": "2014-09-26T16:30:00.000000Z"
   },
-  "NominalDate": "2014-09-26T16:00:00Z",
+  "NominalDate": "2014-09-26T16:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/lst_global_5km_hourly_v2.json
+++ b/lst_global_5km_hourly_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_LST_202501121100_GLOBE_GEO_V2.1.2_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2025-01-12T11:42:16Z",
+  "OriginDate": "2025-01-12T11:42:16.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/land_surface_temperature/lst_5km_v2_hourly/2025/20250112/c_gls_LST_202501121100_GLOBE_GEO_V2.1.2.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2025-01-12T10:30:00Z",
-    "End": "2025-01-12T11:30:00Z"
+    "Start": "2025-01-12T10:30:00.000000Z",
+    "End": "2025-01-12T11:30:00.000000Z"
   },
-  "NominalDate": "2025-01-12T11:00:00Z",
+  "NominalDate": "2025-01-12T11:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,7 +114,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/ndvi-lts_global_1km_10daily_v2.json
+++ b/ndvi-lts_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI-LTS_1999-2017-1001_GLOBE_VGT-PROBAV_V2.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-02-07T17:18:58Z",
+  "OriginDate": "2019-02-07T17:18:58.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_1km_v2_statistics/c_gls_NDVI-LTS_1999-2017-1001_GLOBE_VGT-PROBAV_V2.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "1999-01-01T00:00:00Z",
-    "End": "2017-12-31T23:59:59Z"
+    "Start": "1999-01-01T00:00:00.000000Z",
+    "End": "2017-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "1999-10-01T00:00:00Z",
+  "NominalDate": "1999-10-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi-lts_global_1km_10daily_v3.json
+++ b/ndvi-lts_global_1km_10daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI-LTS_1999-2019-0511_GLOBE_VGT-PROBAV_V3.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2021-03-01T17:26:45Z",
+  "OriginDate": "2021-03-01T17:26:45.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_1km_v3_statistics/c_gls_NDVI-LTS_1999-2019-0511_GLOBE_VGT-PROBAV_V3.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "1999-01-01T00:00:00Z",
-    "End": "2019-12-31T23:59:59Z"
+    "Start": "1999-01-01T00:00:00.000000Z",
+    "End": "2019-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "1999-05-11T00:00:00Z",
+  "NominalDate": "1999-05-11T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi-sts_global_1km_10daily_v3.json
+++ b/ndvi-sts_global_1km_10daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI-STS_2015-2019-1211_GLOBE_PROBAV_V3.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2021-03-01T16:59:29Z",
+  "OriginDate": "2021-03-01T16:59:29.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_1km_v3_statistics/c_gls_NDVI-STS_2015-2019-1211_GLOBE_PROBAV_V3.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2015-01-01T00:00:00Z",
-    "End": "2019-12-31T23:59:59Z"
+    "Start": "2015-01-01T00:00:00.000000Z",
+    "End": "2019-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "2015-12-11T00:00:00Z",
+  "NominalDate": "2015-12-11T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi_global_1km_10daily_v2.json
+++ b/ndvi_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI_200112210000_GLOBE_VGT_V2.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2017-03-13T20:06:17Z",
+  "OriginDate": "2017-03-13T20:06:17.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_1km_v2_10daily/2001/20011221/c_gls_NDVI_200112210000_GLOBE_VGT_V2.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2001-12-21T00:00:00Z",
-    "End": "2001-12-31T23:59:59Z"
+    "Start": "2001-12-21T00:00:00.000000Z",
+    "End": "2001-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "2001-12-21T00:00:00Z",
+  "NominalDate": "2001-12-21T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi_global_1km_10daily_v3.json
+++ b/ndvi_global_1km_10daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI_202004010000_GLOBE_PROBAV_V3.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2021-02-08T20:43:17Z",
+  "OriginDate": "2021-02-08T20:43:17.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_1km_v3_10daily/2020/20200401/c_gls_NDVI_202004010000_GLOBE_PROBAV_V3.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2020-04-01T00:00:00Z",
-    "End": "2020-04-10T23:59:59Z"
+    "Start": "2020-04-01T00:00:00.000000Z",
+    "End": "2020-04-10T23:59:59.999999Z"
   },
-  "NominalDate": "2020-04-01T00:00:00Z",
+  "NominalDate": "2020-04-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi_global_300m_10daily_v1.json
+++ b/ndvi_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI300_201706010000_GLOBE_PROBAV_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2017-06-12T09:10:53Z",
+  "OriginDate": "2017-06-12T09:10:53.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_300m_v1_10daily/2017/20170601/c_gls_NDVI300_201706010000_GLOBE_PROBAV_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2017-06-01T00:00:00Z",
-    "End": "2017-06-10T23:59:59Z"
+    "Start": "2017-06-01T00:00:00.000000Z",
+    "End": "2017-06-10T23:59:59.999999Z"
   },
-  "NominalDate": "2017-06-01T00:00:00Z",
+  "NominalDate": "2017-06-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/ndvi_global_300m_10daily_v2.json
+++ b/ndvi_global_300m_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NDVI300_202101210000_GLOBE_OLCI_V2.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2021-02-08T12:25:55Z",
+  "OriginDate": "2021-02-08T12:25:55.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/ndvi/ndvi_300m_v2_10daily/2021/20210121/c_gls_NDVI300_202101210000_GLOBE_OLCI_V2.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2021-01-21T00:00:00Z",
-    "End": "2021-01-31T23:59:59Z"
+    "Start": "2021-01-21T00:00:00.000000Z",
+    "End": "2021-01-31T23:59:59.999999Z"
   },
-  "NominalDate": "2021-01-21T00:00:00Z",
+  "NominalDate": "2021-01-21T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -109,12 +109,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/npp_global_300m_10daily_v1.json
+++ b/npp_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_NPP300-RT6_202307100000_GLOBE_OLCI_V1.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-09-15T07:29:01Z",
+  "OriginDate": "2023-09-15T07:29:01.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/dry_matter_productivity/npp_300m_v1_10daily/2023/20230710/c_gls_NPP300-RT6_202307100000_GLOBE_OLCI_V1.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-07-01T00:00:00Z",
-    "End": "2023-07-10T23:59:59Z"
+    "Start": "2023-07-01T00:00:00.000000Z",
+    "End": "2023-07-10T23:59:59.999999Z"
   },
-  "NominalDate": "2023-07-10T00:00:00Z",
+  "NominalDate": "2023-07-10T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,12 +114,12 @@
     {
       "Name": "platformShortName",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     },
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/ssm_europe_1km_daily_v1.json
+++ b/ssm_europe_1km_daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SSM1km_201909030000_CEURO_S1CSAR_V1.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-09-15T22:57:05Z",
+  "OriginDate": "2019-09-15T22:57:05.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/surface_soil_moisture/ssm_1km_v1_daily/2019/20190903/c_gls_SSM1km_201909030000_CEURO_S1CSAR_V1.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2019-09-03T00:00:00Z",
-    "End": "2019-09-03T23:59:59Z"
+    "Start": "2019-09-03T00:00:00.000000Z",
+    "End": "2019-09-03T23:59:59.999999Z"
   },
-  "NominalDate": "2019-09-03T00:00:00Z",
+  "NominalDate": "2019-09-03T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/swi-static_global_12.5km_daily_v1.json
+++ b/swi-static_global_12.5km_daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SWI-STATIC-CI_201101010000_GLOBE_SWI-GLDAS_V1.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2024-06-06T10:07:50Z",
+  "OriginDate": "2024-06-06T10:07:50.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/soil_water_index/swi_12.5km_v3_static/c_gls_SWI-STATIC-CI_201101010000_GLOBE_SWI-GLDAS_V1.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2011-01-01T00:00:00Z",
-    "End": "2011-12-31T23:59:59Z"
+    "Start": "2011-01-01T00:00:00.000000Z",
+    "End": "2011-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "2011-01-01T00:00:00Z",
+  "NominalDate": "2011-01-01T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -119,7 +119,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/swi-timeseries_global_12.5km_daily_v3.json
+++ b/swi-timeseries_global_12.5km_daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SWI-TS_202312310000_C0348_ASCAT_V3.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2024-01-10T04:19:16Z",
+  "OriginDate": "2024-01-10T04:19:16.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/soil_water_index/swi_12.5km_v3_time-series/2023/20231231/c_gls_SWI-TS_202312310000_C0348_ASCAT_V3.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-12-31T00:00:00Z",
-    "End": "2023-12-31T23:59:59.999Z"
+    "Start": "2023-12-31T00:00:00.000000Z",
+    "End": "2023-12-31T23:59:59.999999Z"
   },
-  "NominalDate": "2023-12-31T00:00:00Z",
+  "NominalDate": "2023-12-31T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -119,7 +119,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/swi_europe_1km_daily_v1.json
+++ b/swi_europe_1km_daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SWI1km_201608131200_CEURO_SCATSAR_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-03-30T08:03:33Z",
+  "OriginDate": "2019-03-30T08:03:33.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/soil_water_index/swi_1km_v1_daily/2016/20160813/c_gls_SWI1km_201608131200_CEURO_SCATSAR_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2016-08-12T12:00:01Z",
-    "End": "2016-08-13T12:00:00Z"
+    "Start": "2016-08-12T12:00:01.000000Z",
+    "End": "2016-08-13T12:00:00.000000Z"
   },
-  "NominalDate": "2016-08-13T12:00:00Z",
+  "NominalDate": "2016-08-13T12:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/swi_global_12.5km_10daily_v3.json
+++ b/swi_global_12.5km_10daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SWI10_201206211200_GLOBE_ASCAT_V3.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2018-10-30T10:05:40Z",
+  "OriginDate": "2018-10-30T10:05:40.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/soil_water_index/swi_12.5km_v3_10daily/2012/20120621/c_gls_SWI10_201206211200_GLOBE_ASCAT_V3.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2012-06-20T12:00:00Z",
-    "End": "2012-06-30T12:00:00Z"
+    "Start": "2012-06-20T12:00:00.000000Z",
+    "End": "2012-06-30T12:00:00.000000Z"
   },
-  "NominalDate": "2012-06-21T12:00:00Z",
+  "NominalDate": "2012-06-21T12:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,7 +114,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/swi_global_12.5km_daily_v3.json
+++ b/swi_global_12.5km_daily_v3.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_SWI_202302141200_GLOBE_ASCAT_V3.2.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2023-02-14T14:52:45Z",
+  "OriginDate": "2023-02-14T14:52:45.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/soil_water_index/swi_12.5km_v3_daily/2023/20230214/c_gls_SWI_202302141200_GLOBE_ASCAT_V3.2.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2023-02-13T12:00:00Z",
-    "End": "2023-02-14T12:00:00Z"
+    "Start": "2023-02-13T12:00:00.000000Z",
+    "End": "2023-02-14T12:00:00.000000Z"
   },
-  "NominalDate": "2023-02-14T12:00:00Z",
+  "NominalDate": "2023-02-14T12:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [
@@ -114,7 +114,7 @@
     {
       "Name": "platformAcronym",
       "ValueType": "String",
-      "Value": null
+      "Value": "unspecified"
     }
   ]
 }

--- a/wb_global_1km_10daily_v2.json
+++ b/wb_global_1km_10daily_v2.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_WB_200109110000_GLOBE_VGT_V2.1.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2017-08-22T12:02:08Z",
+  "OriginDate": "2017-08-22T12:02:08.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/water_bodies/wb_1km_v2_10daily/2001/20010911/c_gls_WB_200109110000_GLOBE_VGT_V2.1.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2001-09-11T00:00:00Z",
-    "End": "2001-09-20T23:59:59Z"
+    "Start": "2001-09-11T00:00:00.000000Z",
+    "End": "2001-09-20T23:59:59.999999Z"
   },
-  "NominalDate": "2001-09-11T00:00:00Z",
+  "NominalDate": "2001-09-11T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [

--- a/wb_global_300m_10daily_v1.json
+++ b/wb_global_300m_10daily_v1.json
@@ -2,7 +2,7 @@
   "@odata.context": "$metadata#Products(Attributes())",
   "Name": "c_gls_WB300_201902210000_GLOBE_PROBAV_V1.0.1_nc",
   "EvictionDate": "9999-12-31T23:59:59.999999Z",
-  "OriginDate": "2019-03-02T10:59:22Z",
+  "OriginDate": "2019-03-02T10:59:22.000000Z",
   "Online": true,
   "ContentType": "application/netcdf",
   "Link": "/data/MTDA/Copernicus/Land/global/netcdf/water_bodies/wb_300m_v1_10daily/2019/20190221/c_gls_WB300_201902210000_GLOBE_PROBAV_V1.0.1.nc",
@@ -14,10 +14,10 @@
   "DecompressionStep": false,
   "CompressionType": null,
   "ContentDate": {
-    "Start": "2019-02-21T00:00:00Z",
-    "End": "2019-02-28T23:59:59Z"
+    "Start": "2019-02-21T00:00:00.000000Z",
+    "End": "2019-02-28T23:59:59.999999Z"
   },
-  "NominalDate": "2019-02-21T00:00:00Z",
+  "NominalDate": "2019-02-21T00:00:00.000000Z",
   "GeoFootprint": {
     "type": "Polygon",
     "coordinates": [


### PR DESCRIPTION
- use "unspecified" instead of _null_
- use microsecond precision for datetime fields